### PR TITLE
Check for deprecation warning

### DIFF
--- a/src/Mjml.php
+++ b/src/Mjml.php
@@ -138,6 +138,9 @@ class Mjml
             ? $this->getSideCarResult($arguments)
             : $this->getLocalResult($arguments);
 
+
+        $resultString = $this->checkForDeprecationWarning($resultString);
+
         $resultProperties = json_decode($resultString, true);
 
         if (array_key_exists('mjmlError', $resultProperties)) {
@@ -145,6 +148,17 @@ class Mjml
         }
 
         return new MjmlResult($resultProperties);
+    }
+
+    protected function checkForDeprecationWarning(string $result): string
+    {
+        $deprecationWarning = 'MJML v3 syntax detected, migrating to MJML v4 syntax. Use mjml -m to get the migrated MJML.';
+
+        if (str_contains($result, $deprecationWarning)) {
+            $result = str_replace($deprecationWarning, '', $result);
+        }
+
+        return $result;
     }
 
     protected function getCommand(array $arguments): array


### PR DESCRIPTION
I was just trying to parse `mjml` to `html` but I got the following error message: 

> In Mjml.php line 143:
>                                                                               
> array_key_exists(): Argument #2 ($array) must be of type array, null given

Then I checked the `$resultString` in the `mjml.php` and it seems I received the following data when I dump the `$resultString`:

> MJML v3 syntax detected, migrating to MJML v4 syntax. Use mjml -m to get the migrated MJML. {"mjmlError":"TypeError: Cannot read properties of undefined (reading 'tagName')"}

This causes the code not being able to parse the result to json. I added a check to see if the resultString contains the deprecation warning. This code can probably be improved but it works for now. Please let me know if I can do anything to improve this PR. I can try to add tests for example.