### PR TITLE
MJML v5.0 Alpha compatibility

### DIFF
--- a/bin/mjml.mjs
+++ b/bin/mjml.mjs
@@ -8,7 +8,7 @@ const options = args[1];
 let result = ''
 
 try {
-    result = mjml2html(mjml, options);
+    result = await mjml2html(mjml, options);
 } catch (exception) {
     const errorString = JSON.stringify({mjmlError: exception.toString()});
 


### PR DESCRIPTION
This PR adds compatibility with the latest MJML v5.0 Alpha. The `mjml2html` function now returns a `Promise` instead of running synchronously. Compatibility is simple since we can just use a top-level `await` here, which will work with previous versions since `await` will just wrap a value in a Promise if the value is not already a Promise.

The reason for patching this and adding alpha version compatibility is due to MJML v4.0 currently relying on a package that has a high severity security vulnerability that isn't going to be patched:

https://github.com/mjmlio/mjml/issues/2589#issuecomment-2076912328

```
html-minifier *
Severity: high
kangax html-minifier REDoS vulnerability - https://github.com/advisories/GHSA-pfq8-rq6v-vf5m
fix available via npm audit fix --force
Will install mjml@1.3.4, which is a breaking change
node_modules/html-minifier
mjml-cli <=5.0.0-alpha.0
Depends on vulnerable versions of html-minifier
Depends on vulnerable versions of mjml-core
Depends on vulnerable versions of mjml-migrate
node_modules/mjml-cli
mjml 0.0.1-future || 2.0.0-beta.3 - 5.0.0-alpha.0
Depends on vulnerable versions of mjml-cli
Depends on vulnerable versions of mjml-core
Depends on vulnerable versions of mjml-migrate
Depends on vulnerable versions of mjml-preset-core
node_modules/mjml
mjml-core <=4.15.3
Depends on vulnerable versions of html-minifier
Depends on vulnerable versions of mjml-migrate
node_modules/mjml-core
mjml-accordion <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-accordion
mjml-body <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-body
mjml-button <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-button
mjml-preset-core <=4.15.3
Depends on vulnerable versions of mjml-accordion
Depends on vulnerable versions of mjml-body
Depends on vulnerable versions of mjml-button
Depends on vulnerable versions of mjml-carousel
Depends on vulnerable versions of mjml-column
Depends on vulnerable versions of mjml-divider
Depends on vulnerable versions of mjml-group
Depends on vulnerable versions of mjml-head
Depends on vulnerable versions of mjml-head-attributes
Depends on vulnerable versions of mjml-head-breakpoint
Depends on vulnerable versions of mjml-head-font
Depends on vulnerable versions of mjml-head-html-attributes
Depends on vulnerable versions of mjml-head-preview
Depends on vulnerable versions of mjml-head-style
Depends on vulnerable versions of mjml-head-title
Depends on vulnerable versions of mjml-hero
Depends on vulnerable versions of mjml-image
Depends on vulnerable versions of mjml-navbar
Depends on vulnerable versions of mjml-raw
Depends on vulnerable versions of mjml-section
Depends on vulnerable versions of mjml-social
Depends on vulnerable versions of mjml-spacer
Depends on vulnerable versions of mjml-table
Depends on vulnerable versions of mjml-text
Depends on vulnerable versions of mjml-wrapper
node_modules/mjml-preset-core
mjml-carousel <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-carousel
mjml-column <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-column
mjml-divider <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-divider
mjml-group <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-group
mjml-head <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-head
mjml-head-attributes <=2.0.4 || 4.0.0-alpha.1 - 4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-head-attributes
mjml-head-breakpoint <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-head-breakpoint
mjml-head-font 4.0.0-alpha.1 - 4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-head-font
mjml-head-html-attributes <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-head-html-attributes
mjml-head-preview 4.0.0-alpha.3 - 4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-head-preview
mjml-head-style 4.0.0-alpha.1 - 4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-head-style
mjml-head-title 4.0.0-alpha.1 - 4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-head-title
mjml-hero <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-hero
mjml-image <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-image
mjml-migrate 4.0.0-beta.1 - 4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-migrate
mjml-navbar <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-navbar
mjml-raw <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-raw
mjml-section <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-section
mjml-social <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-social
mjml-spacer <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-spacer
mjml-table <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-table
mjml-text <=4.15.3
Depends on vulnerable versions of mjml-core
node_modules/mjml-text
mjml-wrapper <=4.15.3
Depends on vulnerable versions of mjml-core
Depends on vulnerable versions of mjml-section
node_modules/mjml-wrapper

31 high severity vulnerabilities
```